### PR TITLE
Improve regular expression

### DIFF
--- a/editor/emacs/gotests.el
+++ b/editor/emacs/gotests.el
@@ -15,7 +15,7 @@
       (erase-buffer))
 
     ;; Only run when buffer is test file
-    (if (string-match "_test.go" (buffer-file-name))
+    (if (string-match-p "_test\\.go\\'" (buffer-file-name))
         (progn
           (call-process "gotests" nil buf nil "-w" "-r" (buffer-file-name))
           (revert-buffer :ignore-auto :noconfirm)))))


### PR DESCRIPTION
`string-match` takes regular expression as first argument. So '.'
matches any characters, it should be escaped for using as a 'dot'
character. And put end of string anchor("\'" like PCRE's "\z") for
better matching.

And `string-match-p` instead of `string-match`, `string-match-p` does not
overwrite previous captured groups.

Results of original regexp and this regexp are as below.

``` lisp
(string-match "_test.go" "a_test.go")           ;; => 1
(string-match "_test.go" "_testggo")            ;; => 0
(string-match "_test.go" "_test.go.jsx")        ;; => 0

(string-match-p "_test\\.go\\'" "a_test.go")    ;; => 1
(string-match-p "_test\\.go\\'" "_testggo")     ;; => nil
(string-match-p "_test\\.go\\'" "_test.go.jsx") ;; => nil
```
